### PR TITLE
fix: cross platform capability by path separator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const staticImport: PluginImpl<RollupStaticImportPluginOptions> = options => {
     },
     buildStart() {
       // emit matching files and add them to watch list at the start of build
-      absoluteIncludes.flatMap(inc => glob.sync(inc)).forEach(id => {
+      absoluteIncludes.flatMap(inc => glob.sync(inc.split(path.sep).join('/'))).forEach(id => {
         this.emitFile({
           type: 'asset',
           source: fs.readFileSync(id),

--- a/test/rollup-plugin-static-import.test.ts
+++ b/test/rollup-plugin-static-import.test.ts
@@ -29,5 +29,5 @@ test('staticImport outputs files correctly', async () => {
     'sample.jpg',
     'sub-dir/sample.jpg',
     'sub-dir/sub-sub-dir/sample.jpg'
-  ])
+  ].map(p => path.normalize(p)))
 })


### PR DESCRIPTION
'glob.sync'(glob@8.1.0) cannot match the path correctly in Windows systems.

The plugin did not handle path separators, which resulted in path matching failure in Windows systems.

PS: The test file is also.